### PR TITLE
Add Terraform templates for Azure deployment

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,11 @@
+provider "azurerm" {
+  features {}
+}
+
+provider "local" {
+  version = "~> 2.1"
+}
+
+provider "template" {
+  version = "~> 2.1"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "storage_account_name" {
+  value = azurerm_storage_account.example.name
+}
+
+output "datalake_filesystem_id" {
+  value = azurerm_storage_data_lake_gen2_filesystem.example.id
+}

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -1,0 +1,21 @@
+resource "azurerm_resource_group" "example" {
+  name     = "example-resources"
+  location = "West Europe"
+}
+
+resource "azurerm_storage_account" "example" {
+  name                     = "examplestorageacct"
+  resource_group_name      = azurerm_resource_group.example.name
+  location                 = azurerm_resource_group.example.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+
+  tags = {
+    environment = "staging"
+  }
+}
+
+resource "azurerm_storage_data_lake_gen2_filesystem" "example" {
+  name               = "example-filesystem"
+  storage_account_id = azurerm_storage_account.example.id
+}


### PR DESCRIPTION
This pull request adds Terraform configuration files to manage resources involved in the ETL project for Azure deployment. The configuration includes:

1. **main.tf**: Defines the Azure provider and additional providers.
2. **resources.tf**: Defines resources such as Azure Resource Group, Storage Account, and Data Lake Storage Gen2 Filesystem.
3. **outputs.tf**: Specifies output variables for the storage account name and filesystem ID.

These templates will help in automating the deployment of necessary Azure resources for the project.